### PR TITLE
fixes issue Nginx 502 #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ And run it like this
 
     docker run --rm=true -p 8888:80 -v /path/repo:/repos gitlist
 
-The web interface will be available on host machine at port 80 and will show
+The web interface will be available on host machine at port 8888 and will show
 repositories inside /path/repo

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,4 @@
+user www-data;
 daemon off;
 events {
     worker_connections  1024;
@@ -28,10 +29,10 @@ http {
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 
           # if you're using php5-fpm via tcp
-          fastcgi_pass 127.0.0.1:9000;
+          # fastcgi_pass 127.0.0.1:9000;
 
           # if you're using php5-fpm via socket
-          #fastcgi_pass unix:/var/run/php5-fpm.sock;
+          fastcgi_pass unix:/var/run/php5-fpm.sock;
 
           include /etc/nginx/fastcgi_params;
       }


### PR DESCRIPTION
Fixes the issue caused by the ubuntu php5-fpm package now listening to a unix socket instead of the former, less secure, tcp://127.0.0.1:9000 