### PR TITLE
Specified ubuntu base image version to 14.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:14.04
 RUN apt-get update
 RUN apt-get -y install git nginx-full php5-fpm curl
 ADD https://s3.amazonaws.com/gitlist/gitlist-master.tar.gz /var/www/


### PR DESCRIPTION
Solution to issue #3 
Latest Ubuntu base image comes with php 7 as default so apt-get install php5-fpm fails. Ubuntu 14.04 version is also LTS so it should be good. Docker build tested to work after this change.
